### PR TITLE
Prevent cue_next_image from being optimized out

### DIFF
--- a/laser-tag software/main.c
+++ b/laser-tag software/main.c
@@ -60,7 +60,7 @@ static const uint8_t *images[] = {
 };
 static const int image_count = sizeof images / sizeof *images;
 static int current_image = 0;
-static int cue_next_image = 0;
+static volatile int cue_next_image = 0;
 
 
 ////////////////////////////


### PR DESCRIPTION
Clang is more aggressive and optimizes out cue_next_image. Mark it as volatile so that we can still cycle images.
